### PR TITLE
Fix directory path in build_core.sh

### DIFF
--- a/build_core.sh
+++ b/build_core.sh
@@ -26,7 +26,7 @@ build_ng() {
 }
 
 build_api() {
-  cd CSETWebApi/csetweb_api/CSETWeb_ApiCore
+  cd CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore
 
   echo 'Cleaning Project...'
 


### PR DESCRIPTION
## Summary
- fix incorrect directory path for API project in `build_core.sh`

## Testing
- `shellcheck build_core.sh` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_685f0c79036483329876b07d0dcd1d09